### PR TITLE
main関数から渡す関数をトレイトベースの実装に変更(依存性逆転の原則の導入)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,6 @@
+pub struct Config;
+
+impl Config {
+    pub const SCHEMA_FILE_PATH: &'static str = "schema.txt";
+    pub const MAX_VALUE_LENGTH: usize = 4096;
+}

--- a/src/core/file_parser.rs
+++ b/src/core/file_parser.rs
@@ -3,9 +3,8 @@ use std::fs::{self, File};
 use std::io::{self, BufRead, Error};
 use std::path::Path;
 
+use crate::config::Config;
 use crate::utils::display::display_json_map;
-
-pub const MAX_VALUE_LENGTH: usize = 4096;
 
 /// .confファイルのパース処理
 pub fn parse_conf_file(
@@ -82,7 +81,7 @@ pub fn parse_conf_to_map(file_path: &Path) -> io::Result<FxHashMap<String, Strin
             let value: &str = value.trim();
 
             // 値が4096文字を超えた場合はパニック
-            if value.len() > MAX_VALUE_LENGTH {
+            if value.len() > Config::MAX_VALUE_LENGTH {
                 panic!("Error: キー '{}' の値が4096文字を超えています。👀", key);
             }
             map.insert(key.to_string(), value.to_string());

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -5,21 +5,31 @@ pub mod schema;
 use rustc_hash::FxHashMap;
 use std::{io, path::Path};
 
-type ParseFn =
-    fn(&[&str], &FxHashMap<String, String>, &mut FxHashMap<String, String>) -> io::Result<()>;
+pub trait ParseFiles {
+    fn parse_all_conf_files(
+        &self,
+        directories: &[&str],
+        schema: &FxHashMap<String, String>,
+        result_map: &mut FxHashMap<String, String>,
+    ) -> io::Result<()>;
+}
+
+pub trait SchemaLoader {
+    fn load_schema(&self, schema_file: &Path) -> io::Result<FxHashMap<String, String>>;
+}
 
 /// スキーマファイルを読み込み、ディレクトリを再帰的に探索してファイルをパースし、スキーマに基づいて型の整合性を検証
 pub fn validate_schema_and_parse_files(
     schema_file: &str,
     directories: &[&str],
-    parse_all_files_fn: ParseFn,
-    load_schema_fn: fn(&Path) -> io::Result<FxHashMap<String, String>>,
+    parser: &impl ParseFiles,
+    schema: &impl SchemaLoader,
     result_map: &mut FxHashMap<String, String>,
 ) -> io::Result<()> {
     let schema_path: &Path = Path::new(schema_file);
 
     // スキーマファイルを読み込む
-    let schema: FxHashMap<String, String> = match load_schema_fn(schema_path) {
+    let schema: FxHashMap<String, String> = match schema.load_schema(schema_path) {
         Ok(schema) => schema,
         Err(e) => {
             eprintln!("スキーマファイルの読み込みに失敗しました: {}", e);
@@ -28,7 +38,7 @@ pub fn validate_schema_and_parse_files(
     };
 
     // ディレクトリを探索し、ファイルをパースして結果を検証
-    match parse_all_files_fn(directories, &schema, result_map) {
+    match parser.parse_all_conf_files(directories, &schema, result_map) {
         Ok(_) => {
             println!("全てのファイルが正常にパースされ、スキーマに従っています。");
             Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
+pub mod config;
 pub mod core;
 pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod config;
 mod core;
 mod utils;
 
@@ -26,7 +27,7 @@ fn main() -> io::Result<()> {
 
     // スキーマ検証と.confファイルのパースを実行
     let result: Result<(), io::Error> = core::validate_schema_and_parse_files(
-        "schema.txt",
+        config::Config::SCHEMA_FILE_PATH,
         &directories,
         &parser,
         &schema,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,10 @@
 mod core;
 mod utils;
+
+use core::{directory_parser::DirectoryParser, schema::LoadSchema};
 use rustc_hash::FxHashMap;
 use std::io;
 
-use core::directory_parser;
-use core::schema;
 use utils::output::handle_output;
 
 fn main() -> io::Result<()> {
@@ -21,12 +21,15 @@ fn main() -> io::Result<()> {
     // パース結果を格納するマップ
     let mut result_map: FxHashMap<String, String> = FxHashMap::default();
 
+    let parser = DirectoryParser;
+    let schema = LoadSchema;
+
     // スキーマ検証と.confファイルのパースを実行
     let result: Result<(), io::Error> = core::validate_schema_and_parse_files(
         "schema.txt",
         &directories,
-        directory_parser::parse_all_conf_files,
-        schema::load_schema,
+        &parser,
+        &schema,
         &mut result_map,
     );
 

--- a/tests/parse_conf_tests.rs
+++ b/tests/parse_conf_tests.rs
@@ -1,7 +1,8 @@
 #[cfg(test)]
 mod tests {
+    use linux_conf_parser::config::Config;
     use linux_conf_parser::core::directory_parser::DirectoryParser;
-    use linux_conf_parser::core::file_parser::{parse_conf_to_map, MAX_VALUE_LENGTH};
+    use linux_conf_parser::core::file_parser::parse_conf_to_map;
     use linux_conf_parser::core::schema::validate_against_schema;
     use linux_conf_parser::core::schema::LoadSchema;
     use linux_conf_parser::core::{ParseFiles, SchemaLoader};
@@ -63,7 +64,7 @@ mod tests {
     #[test]
     #[should_panic(expected = "値が4096文字を超えています")]
     fn test_value_too_long() {
-        let long_value: String = "A".repeat(MAX_VALUE_LENGTH + 1);
+        let long_value: String = "A".repeat(Config::MAX_VALUE_LENGTH + 1);
         let content: String = format!("long.key = {}", long_value);
         let file_path: PathBuf = setup_test_file("long_value.conf", &content);
 


### PR DESCRIPTION
### Before
main関数から具体的な実装（parse_all_conf_files関数やload_schema関数）を直接渡すのではなく、
```rust
// 直接渡している状態
let result: Result<(), io::Error> = core::validate_schema_and_parse_files(
    "schema.txt",
    &directories,
    directory_parser::parse_all_conf_files,
    schema::load_schema,
    &mut result_map,
);
```
### After
抽象であるトレイト（ParseFilesトレイトを実装したDirectoryParser構造体、SchemaLoaderトレイトを実装したLoadSchema構造体）を使用して、依存性を注入する形に変更

ついでに"schema.txt"もconfig.rsで定数を定義して使えるように変更 → このコミットfix(config): Config構造体で定義された定数を使用するように変更
```rust
// 依存関係を注入する形にする
let parser = DirectoryParser;
let schema = LoadSchema;

// スキーマ検証と.confファイルのパースを実行
let result: Result<(), io::Error> = core::validate_schema_and_parse_files(
    config::Config::SCHEMA_FILE_PATH,
    &directories,
    &parser,
    &schema,
    &mut result_map,
);

```
---
### 手順
### core/mod.rs
ParseFilesトレイトを実装
(directory_parserのparse_all_conf_files関数をDirectoryParser構造体のメソッドとして実装)
SchemaLoaderトレイトを実装
(schemaのload_schema関数をLoadSchema構造体のメソッドとして実装)
```rust
pub trait ParseFiles {
    fn parse_all_conf_files(
        &self,
        directories: &[&str],
        schema: &FxHashMap<String, String>,
        result_map: &mut FxHashMap<String, String>,
    ) -> io::Result<()>;
}

pub trait SchemaLoader {
    fn load_schema(&self, schema_file: &Path) -> io::Result<FxHashMap<String, String>>;
}
```
### core/directory_parser.rs
DirectoryParser構造体はParseFilesトレイトを実装(impl)
```rust
pub struct DirectoryParser;

impl ParseFiles for DirectoryParser {
    /// 指定されたディレクトリ内のすべての設定ファイルをパースし、結果を検証
    fn parse_all_conf_files(
        &self,
        directories: &[&str],
        schema: &FxHashMap<String, String>,
        result_map: &mut FxHashMap<String, String>,
    ) -> io::Result<()> {
```

### core/schema.rs
LoadSchema構造体はSchemaLoaderトレイトを実装(impl)
```rust
pub struct LoadSchema;

impl SchemaLoader for LoadSchema {
    /// スキーマファイルを読み込み、キーと型のペアを返す
    fn load_schema(&self, file_path: &Path) -> io::Result<FxHashMap<String, String>> {
```

### core/mod.rs
トレイト境界（trait bound）を利用した型定義（impl Trait）
関数の引数として「トレイトを実装した型」を受け取るための型定義を行う(&impl ParseFiles, &impl SchemaLoader)

validate_schema_and_parse_files関数内で直接関数を渡していた部分をトレイトのメソッド呼び出しに置き換え
```rust
pub fn validate_schema_and_parse_files(
    schema_file: &str,
    directories: &[&str],
    parser: &impl ParseFiles,
    schema: &impl SchemaLoader,
    result_map: &mut FxHashMap<String, String>,
) -> io::Result<()> {

// 構造体が実装しているトレイトメソッド（parse_all_conf_files および load_schema）を呼び出して処理を行う
...

    // スキーマファイルを読み込む
    let schema: FxHashMap<String, String> = match schema.load_schema(schema_path) {

...

    // ディレクトリを探索し、ファイルをパースして結果を検証
    match parser.parse_all_conf_files(directories, &schema, result_map) {

```




### main.rs
mainでDirectoryParser構造体、LoadSchema構造体のインスタンスを作成
directory_parserのparse_all_conf_files関数にDirectoryParser、LoadSchemaを渡す
```rust
    let parser = DirectoryParser;
    let schema = LoadSchema;

    // スキーマ検証と.confファイルのパースを実行
    let result: Result<(), io::Error> = core::validate_schema_and_parse_files(
        config::Config::SCHEMA_FILE_PATH,
        &directories,
        &parser,
        &schema,
        &mut result_map,
    );
```

**tests/**
**bench/**
ベンチマークとテストコードをトレイトを使用した新しい実装に対応
